### PR TITLE
Change webhook-deployer config to use trunk over peek1

### DIFF
--- a/peekaboo/docs/DEPLOY.md
+++ b/peekaboo/docs/DEPLOY.md
@@ -129,7 +129,7 @@ journalctl --user -u peekaboo -f
 
 ```bash
 cd /home/trevor/pub_musings
-git pull origin peek1
+git pull origin trunk
 ```
 
 ### 2. Decrypt secrets
@@ -478,7 +478,7 @@ sqlite3 data/peekaboo.db "
 
 ## Webhook Deployer
 
-The webhook-deployer is configured in `../webhook-deployer/config.yaml` to deploy both frontend and backend when changes are pushed to the `peek1` branch.
+The webhook-deployer is configured in `../webhook-deployer/config.yaml` to deploy both frontend and backend when changes are pushed to the `trunk` branch.
 
 Deploy scripts location:
 - `../webhook-deployer/scripts/deploy-peekaboo-frontend.sh`

--- a/webhook-deployer/config.yaml
+++ b/webhook-deployer/config.yaml
@@ -31,7 +31,7 @@ sites:
   - name: peekaboo-frontend
     path: /home/trevor/pub_musings/peekaboo/frontend
     path_prefix: peekaboo/frontend/
-    branch: peek1
+    branch: trunk
     repository: tpott/pub_musings
     repo_path: /home/trevor/pub_musings
     deploy_script: /home/trevor/pub_musings/webhook-deployer/scripts/deploy-peekaboo-frontend.sh
@@ -39,7 +39,7 @@ sites:
   - name: peekaboo-backend
     path: /home/trevor/pub_musings/peekaboo
     path_prefix: peekaboo/
-    branch: peek1
+    branch: trunk
     repository: tpott/pub_musings
     repo_path: /home/trevor/pub_musings
     deploy_script: /home/trevor/pub_musings/webhook-deployer/scripts/deploy-peekaboo-backend.sh

--- a/webhook-deployer/scripts/deploy-peekaboo-backend.sh
+++ b/webhook-deployer/scripts/deploy-peekaboo-backend.sh
@@ -7,9 +7,9 @@ BACKEND_PORT="${BACKEND_PORT:-8070}"
 cd /home/trevor/pub_musings
 git fetch origin
 
-# Checkout peek1 branch (peekaboo development branch)
-git checkout peek1
-git pull origin peek1
+# Checkout trunk branch (peekaboo development branch)
+git checkout trunk
+git pull origin trunk
 
 cd peekaboo
 

--- a/webhook-deployer/scripts/deploy-peekaboo-frontend.sh
+++ b/webhook-deployer/scripts/deploy-peekaboo-frontend.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 cd /home/trevor/pub_musings
 git fetch origin
 
-# Checkout peek1 branch (peekaboo development branch)
-git checkout peek1
-git pull origin peek1
+# Checkout trunk branch (peekaboo development branch)
+git checkout trunk
+git pull origin trunk
 
 cd peekaboo/frontend
 


### PR DESCRIPTION
## Summary
- Update webhook-deployer config, deploy scripts, and docs to reference `trunk` instead of `peek1` branch

## Test plan
- [ ] Verify webhook-deployer triggers on pushes to `trunk`
- [ ] Confirm peekaboo frontend and backend deploy correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)