### PR TITLE
dvd-ripper: overwrite protection, verify model default, title-frame-scanner

### DIFF
--- a/dvd-ripper/rip.conf.example
+++ b/dvd-ripper/rip.conf.example
@@ -40,5 +40,6 @@ CLAUDE_BIN="$HOME/.local/bin/claude"
 VERIFY_ENABLED="true"
 VERIFY_FRAME_OFFSET="75"
 VERIFY_CLAUDE_ALWAYS="false"
+# Model for Claude verification (default: sonnet)
 VERIFY_MODEL=""
 ANTHROPIC_API_KEY=""

--- a/dvd-ripper/rip.py
+++ b/dvd-ripper/rip.py
@@ -171,6 +171,24 @@ def stage_plan(conf, state):
                 "remote_dir": f"{backup_dest}/{show_name}/{season_dir}",
             })
 
+        # Check for mp4 files that would be overwritten
+        existing_mp4s = []
+        for ep in plan_episodes:
+            mp4 = output_dir / f"{ep['ep_name']}.mp4"
+            if mp4.exists():
+                existing_mp4s.append(mp4.name)
+        if existing_mp4s:
+            names = ", ".join(existing_mp4s)
+            if conf.get("_force"):
+                print(f"WARNING: --force overwriting {len(existing_mp4s)} "
+                      f"existing files: {names}", file=sys.stderr)
+            else:
+                raise RuntimeError(
+                    f"Would overwrite {len(existing_mp4s)} existing files: "
+                    f"{names}. Use --force to override, or set SEASON=/DISC= "
+                    f"to target the correct season and disc."
+                )
+
         ep_end = ep_start + len(plan_episodes) - 1
         state["plan"] = {
             "show_name": show_name,
@@ -315,6 +333,7 @@ def main():
         sys.exit(1)
 
     conf = parse_conf(conf_path)
+    conf["_force"] = args.force
 
     try:
         if args.resume:

--- a/dvd-ripper/tests/eval_verify.py
+++ b/dvd-ripper/tests/eval_verify.py
@@ -7,7 +7,10 @@ are logged but not hard-asserted.
 
 import json
 import shutil
+import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 
 from tests.test_data import AVATAR_DISC_INFO, SHE_RA_DISC_INFO
 from titles import parse_makemkv_info, select_episode_titles
@@ -156,6 +159,51 @@ class TestEvalVerify(unittest.TestCase):
         )
         self.assertTrue(mentions_anomaly,
                         f"Expected Claude to mention duration anomaly: {result}")
+
+
+    def test_eval_title_frame_scanner_invoked(self):
+        """For TV shows with mp4 files, Claude should invoke /title-frame-scanner."""
+        state = self._make_avatar_state()
+        issues = check_episode_count(state)
+
+        # Create a temp dir with small real mp4 files so the skill has
+        # something to scan.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            episodes = state["plan"]["episodes"]
+            for ep in episodes:
+                mp4_name = f"{ep['ep_name']}.mp4"
+                mp4_path = output_dir / mp4_name
+                ep["mp4_path"] = str(mp4_path)
+                # Generate a 2-second silent black video
+                subprocess.run(
+                    [
+                        "ffmpeg", "-y", "-f", "lavfi", "-i",
+                        "color=c=black:s=320x240:d=2",
+                        "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+                        "-t", "2", "-c:v", "libx264", "-c:a", "aac",
+                        "-shortest", str(mp4_path),
+                    ],
+                    capture_output=True,
+                )
+
+            state["plan"]["output_dir"] = str(output_dir)
+            conf = {"RIP_DIR": str(output_dir)}
+            prompt = build_verify_prompt(state, issues, conf)
+
+            result = run_claude_verify(prompt, conf)
+
+            print(f"\n  Claude verdict: {json.dumps(result, indent=2)}")
+            tfc = result.get("title_frame_check")
+            self.assertIsNotNone(
+                tfc,
+                f"Expected title_frame_check in response, got keys: "
+                f"{list(result.keys())}",
+            )
+            self.assertTrue(
+                tfc.get("attempted"),
+                f"Expected title_frame_check.attempted=true, got: {tfc}",
+            )
 
 
 if __name__ == "__main__":

--- a/dvd-ripper/tests/test_overwrite_protection.py
+++ b/dvd-ripper/tests/test_overwrite_protection.py
@@ -1,0 +1,133 @@
+"""Tests for mp4 overwrite protection in stage_plan."""
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from rip import stage_plan
+
+
+def _make_tv_state(disc_label, titles):
+    """Build a minimal state dict for stage_plan with TV media type."""
+    return {
+        "disc_label": disc_label,
+        "media_type": "tv",
+        "titles": titles,
+        "stages": {},
+        "plan": {},
+        "verification": {"issues": []},
+    }
+
+
+def _simple_titles(count):
+    """Create N episode-length titles with unique segments."""
+    return [
+        {
+            "id": i,
+            "duration_secs": 1400,
+            "segment_count": 1,
+            "segments": str(i + 1),
+            "name": "",
+            "filename": f"D1_t{i:02d}.mkv",
+        }
+        for i in range(count)
+    ]
+
+
+class TestOverwriteProtection(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.conf = {
+            "RIP_DIR": self.tmpdir,
+            "BACKUP_DEST": "/backup/Movies",
+            "BACKUP_DEST_TV": "/backup/TV",
+        }
+        # Clear env vars that stage_plan reads
+        for var in ("SHOW_NAME", "SEASON", "DISC", "TITLES"):
+            os.environ.pop(var, None)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        for var in ("SHOW_NAME", "SEASON", "DISC", "TITLES"):
+            os.environ.pop(var, None)
+
+    def test_no_existing_files_succeeds(self):
+        """First disc rip with no existing files should succeed."""
+        state = _make_tv_state("SHOW_S1_D1", _simple_titles(3))
+        result = stage_plan(self.conf, state)
+        self.assertEqual(result["plan"]["season"], 1)
+        self.assertEqual(len(result["plan"]["episodes"]), 3)
+
+    def test_error_when_overwriting_without_force(self):
+        """Should raise RuntimeError when mp4 files would be overwritten."""
+        # Rip disc 1 first
+        state = _make_tv_state("SHOW_S1_D1", _simple_titles(3))
+        result = stage_plan(self.conf, state)
+        # Create the mp4 files that disc 1 would have produced
+        output_dir = Path(result["plan"]["output_dir"])
+        for ep in result["plan"]["episodes"]:
+            (output_dir / f"{ep['ep_name']}.mp4").write_text("fake")
+
+        # Now try to plan another disc=1 rip (same season) without --force
+        state2 = _make_tv_state("SHOW_S1_D1", _simple_titles(3))
+        with self.assertRaises(RuntimeError) as ctx:
+            stage_plan(self.conf, state2)
+        self.assertIn("Would overwrite", str(ctx.exception))
+        self.assertIn("--force", str(ctx.exception))
+        self.assertIn("SEASON=", str(ctx.exception))
+
+    def test_warn_when_overwriting_with_force(self):
+        """Should warn but proceed when --force is set."""
+        conf = {**self.conf, "_force": True}
+        # Create existing files
+        state = _make_tv_state("SHOW_S1_D1", _simple_titles(3))
+        result = stage_plan(conf, state)
+        output_dir = Path(result["plan"]["output_dir"])
+        for ep in result["plan"]["episodes"]:
+            (output_dir / f"{ep['ep_name']}.mp4").write_text("fake")
+
+        # Re-plan with --force should succeed with warning
+        state2 = _make_tv_state("SHOW_S1_D1", _simple_titles(3))
+        with patch("sys.stderr") as mock_stderr:
+            result2 = stage_plan(conf, state2)
+        # Should have proceeded and returned a plan
+        self.assertEqual(len(result2["plan"]["episodes"]), 3)
+
+    def test_she_ra_label_would_overwrite(self):
+        """SHE_RA label defaults to S1D1 — second disc insert would overwrite."""
+        state = _make_tv_state("SHE_RA", _simple_titles(7))
+        os.environ["SHOW_NAME"] = "SHE RA"
+        result = stage_plan(self.conf, state)
+        output_dir = Path(result["plan"]["output_dir"])
+        for ep in result["plan"]["episodes"]:
+            (output_dir / f"{ep['ep_name']}.mp4").write_text("fake")
+
+        # Insert "next disc" — also labeled SHE_RA, also defaults to S1D1
+        state2 = _make_tv_state("SHE_RA", _simple_titles(7))
+        with self.assertRaises(RuntimeError) as ctx:
+            stage_plan(self.conf, state2)
+        self.assertIn("Would overwrite", str(ctx.exception))
+        self.assertIn("7", str(ctx.exception))
+
+    def test_different_season_no_conflict(self):
+        """Setting SEASON=2 should not conflict with Season 01 files."""
+        state = _make_tv_state("SHE_RA", _simple_titles(7))
+        os.environ["SHOW_NAME"] = "SHE RA"
+        result = stage_plan(self.conf, state)
+        output_dir = Path(result["plan"]["output_dir"])
+        for ep in result["plan"]["episodes"]:
+            (output_dir / f"{ep['ep_name']}.mp4").write_text("fake")
+
+        # Now rip season 2 — different output dir, no conflict
+        state2 = _make_tv_state("SHE_RA", _simple_titles(7))
+        os.environ["SEASON"] = "2"
+        result2 = stage_plan(self.conf, state2)
+        self.assertEqual(result2["plan"]["season"], 2)
+        self.assertIn("Season 02", result2["plan"]["output_dir"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dvd-ripper/tests/test_verify_context.py
+++ b/dvd-ripper/tests/test_verify_context.py
@@ -1,0 +1,112 @@
+"""Tests for cross-season episode context in build_verify_prompt."""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify import build_verify_prompt
+
+
+class TestBuildVerifyPromptCrossSeasonContext(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.rip_dir = self.tmpdir
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_state(self, show_name, season, episodes, output_dir):
+        return {
+            "disc_label": "SHE_RA",
+            "media_type": "tv",
+            "plan": {
+                "show_name": show_name,
+                "season": season,
+                "output_dir": output_dir,
+                "episodes": episodes,
+            },
+            "scan_disc": {"makemkv_info": "TINFO:0,9,0,\"0:23:00\""},
+        }
+
+    def _create_mp4s(self, show_name, season, ep_names):
+        """Create fake mp4 files in the expected directory structure."""
+        season_dir = (
+            Path(self.rip_dir) / "TV" / show_name / f"Season {season:02d}"
+        )
+        season_dir.mkdir(parents=True, exist_ok=True)
+        for name in ep_names:
+            (season_dir / name).write_bytes(b"x" * 1000)
+
+    def test_includes_existing_episodes_from_other_seasons(self):
+        """Prompt should list episodes from all seasons, not just current."""
+        # Season 1 already ripped
+        self._create_mp4s("SHE RA", 1, [
+            "SHE RA S01E01.mp4", "SHE RA S01E02.mp4", "SHE RA S01E03.mp4",
+        ])
+        # Currently ripping season 2
+        s2_dir = Path(self.rip_dir) / "TV" / "SHE RA" / "Season 02"
+        s2_dir.mkdir(parents=True, exist_ok=True)
+
+        state = self._make_state("SHE RA", 2, [], str(s2_dir))
+        conf = {"RIP_DIR": self.rip_dir}
+        prompt = build_verify_prompt(state, [], conf)
+
+        self.assertIn("All existing episodes for this show", prompt)
+        self.assertIn("Season 01", prompt)
+        self.assertIn("SHE RA S01E01.mp4", prompt)
+        self.assertIn("SHE RA S01E02.mp4", prompt)
+        self.assertIn("SHE RA S01E03.mp4", prompt)
+
+    def test_includes_file_sizes(self):
+        """File sizes should be included to help detect duplicates."""
+        self._create_mp4s("SHE RA", 1, ["SHE RA S01E01.mp4"])
+
+        s1_dir = Path(self.rip_dir) / "TV" / "SHE RA" / "Season 01"
+        state = self._make_state("SHE RA", 1, [], str(s1_dir))
+        conf = {"RIP_DIR": self.rip_dir}
+        prompt = build_verify_prompt(state, [], conf)
+
+        self.assertIn("1000 bytes", prompt)
+
+    def test_multiple_seasons_listed(self):
+        """Both Season 01 and Season 02 files should appear."""
+        self._create_mp4s("SHE RA", 1, [
+            "SHE RA S01E01.mp4", "SHE RA S01E02.mp4",
+        ])
+        self._create_mp4s("SHE RA", 2, [
+            "SHE RA S02E01.mp4",
+        ])
+
+        s2_dir = Path(self.rip_dir) / "TV" / "SHE RA" / "Season 02"
+        state = self._make_state("SHE RA", 2, [], str(s2_dir))
+        conf = {"RIP_DIR": self.rip_dir}
+        prompt = build_verify_prompt(state, [], conf)
+
+        self.assertIn("Season 01", prompt)
+        self.assertIn("Season 02", prompt)
+        self.assertIn("SHE RA S01E01.mp4", prompt)
+        self.assertIn("SHE RA S02E01.mp4", prompt)
+
+    def test_no_show_dir_no_crash(self):
+        """If the show directory doesn't exist yet, prompt should not crash."""
+        state = self._make_state("NEW SHOW", 1, [], "/tmp/nonexistent")
+        conf = {"RIP_DIR": self.rip_dir}
+        prompt = build_verify_prompt(state, [], conf)
+        self.assertNotIn("All existing episodes", prompt)
+
+    def test_no_show_name_no_crash(self):
+        """If show_name is missing from plan, should not crash."""
+        state = {
+            "disc_label": "DISC",
+            "media_type": "tv",
+            "plan": {"episodes": []},
+            "scan_disc": {"makemkv_info": ""},
+        }
+        conf = {"RIP_DIR": self.rip_dir}
+        prompt = build_verify_prompt(state, [], conf)
+        self.assertNotIn("All existing episodes", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dvd-ripper/verify.py
+++ b/dvd-ripper/verify.py
@@ -49,7 +49,11 @@ Guidelines:
 - List TITLES= IDs in intended episode order based on the makemkv info
 - Analyze the raw makemkv segment data to determine correct title ordering
 - If all episode titles share the same segments (dedup bug), recommend all title IDs
-- Include notes about the code bug if you can identify one from the data\
+- Include notes about the code bug if you can identify one from the data
+- Use the "All existing episodes for this show" section to determine the correct \
+SEASON and DISC values. The next disc should continue from the last existing \
+episode. If Season N is complete and the disc has new episodes, set SEASON=N+1 \
+and DISC=1. Compare file sizes to detect potential duplicates across seasons.\
 """
 
 
@@ -210,6 +214,24 @@ def build_verify_prompt(state, checker_results, conf):
             parts.append(f"  - {mp4.name} ({mp4.stat().st_size} bytes)")
         if not mp4s:
             parts.append("  (no mp4 files)")
+
+    # Include all existing episodes across all seasons for this show
+    plan = state.get("plan", {})
+    show_name = plan.get("show_name")
+    if show_name:
+        show_dir = Path(conf.get("RIP_DIR", "")) / "TV" / show_name
+        if show_dir.is_dir():
+            parts.extend(["", "### All existing episodes for this show"])
+            for season_path in sorted(show_dir.iterdir()):
+                if not season_path.is_dir():
+                    continue
+                mp4s = sorted(season_path.glob("*.mp4"))
+                if mp4s:
+                    parts.append(f"  {season_path.name}/")
+                    for mp4 in mp4s:
+                        parts.append(
+                            f"    - {mp4.name} ({mp4.stat().st_size} bytes)"
+                        )
 
     return "\n".join(parts)
 

--- a/dvd-ripper/verify.py
+++ b/dvd-ripper/verify.py
@@ -20,6 +20,11 @@ VERIFY_SYSTEM_PROMPT = """\
 You are a DVD ripping verification assistant. You analyze rip results to detect \
 issues like missing episodes, incorrect title selection, or combined episodes.
 
+For TV shows: you MUST use the /title-frame-scanner skill on EVERY episode mp4 \
+file to visually verify episode identity. Pass each mp4_path from the plan. \
+Report all results in the title_frame_check field. If the skill is unavailable \
+or a file cannot be scanned, set attempted=true with an error note.
+
 Your response must be ONLY a valid JSON object (no markdown fences, no explanation \
 before or after) with this exact schema:
 {
@@ -31,7 +36,12 @@ before or after) with this exact schema:
      "severity": "error or warning"}
   ],
   "recommendation": "human-readable recommendation for the user",
-  "fix_command": "complete shell command to fix the issue, or null"
+  "fix_command": "complete shell command to fix the issue, or null",
+  "title_frame_check": {
+    "attempted": true,
+    "results": [{"file": "path", "title_text": "detected text or null"}],
+    "error": "error message if scan failed, or null"
+  }
 }
 
 Guidelines:
@@ -248,9 +258,8 @@ def run_claude_verify(prompt, conf):
         "--system-prompt", VERIFY_SYSTEM_PROMPT,
     ]
 
-    model = conf.get("VERIFY_MODEL")
-    if model:
-        cmd.extend(["--model", model])
+    model = conf.get("VERIFY_MODEL") or "sonnet"
+    cmd.extend(["--model", model])
 
     cwd = conf.get("RIP_DIR")
     if cwd and not Path(cwd).is_dir():


### PR DESCRIPTION
## Summary
- **Overwrite protection**: `rip.py` now errors if output mp4 files already exist (prevents accidental re-rips clobbering previous episodes); `--force` overrides
- **Cross-season verify context**: verification prompt now includes all existing episodes for the show, helping Claude detect season/disc mismatches
- **Default verify model to sonnet**: `VERIFY_MODEL` defaults to `sonnet` when unset/empty in `rip.conf`, instead of using the claude CLI default (was hitting opus)
- **Title-frame-scanner in verification**: system prompt now instructs Claude to invoke `/title-frame-scanner` on every TV episode mp4 to visually verify episode identity; results reported in `title_frame_check` response field
- **Eval test**: new `test_eval_title_frame_scanner_invoked` confirms Claude includes `title_frame_check` with `attempted=true`

## Test plan
- [x] `test_eval_title_frame_scanner_invoked` — confirmed fails with old prompt, passes with new prompt
- [x] Existing eval tests unaffected (model default change is backwards-compatible)
- [ ] Manual: re-rip a disc with `VERIFY_CLAUDE_ALWAYS=true` and confirm title-frame-scanner is invoked in journald logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)