### PR TITLE
dvd-ripper: harden post-rip verification (robust verdict parsing + fail-loud)

### DIFF
--- a/dvd-ripper/claude.py
+++ b/dvd-ripper/claude.py
@@ -1,15 +1,86 @@
 """Shared wrapper for invoking the Claude CLI with a JSON-output contract.
 
 Callers supply a system prompt that instructs Claude to return JSON-only. This
-module handles CLI invocation, markdown-fence stripping, and JSON parsing,
-merging any failure note into the caller-supplied fallback dict.
+module handles CLI invocation and lenient JSON extraction (tolerating prose
+preambles, trailing text, and markdown fences around the object), merging any
+failure note into the caller-supplied fallback dict.
 """
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
+
+
+def _balanced_brace_spans(text):
+    """Return each top-level balanced ``{...}`` substring, ignoring braces
+    that appear inside JSON strings (so escaped quotes and literal braces in
+    string values don't throw off the depth count)."""
+    spans = []
+    depth = 0
+    start = None
+    in_str = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}" and depth > 0:
+            depth -= 1
+            if depth == 0:
+                spans.append(text[start:i + 1])
+    return spans
+
+
+def _extract_json(text):
+    """Best-effort extraction of a single JSON object from model output.
+
+    Models sometimes ignore "JSON only" instructions and wrap the object in a
+    prose preamble, a trailing explanation, or a ```fence```. Tries, in order:
+      1. The whole stripped text as JSON.
+      2. The body of a ```...``` fenced block.
+      3. The largest balanced ``{...}`` span that parses (the real verdict
+         dwarfs any stray brace in surrounding prose).
+    Returns the parsed dict, or None if nothing yields a JSON object.
+    """
+    text = (text or "").strip()
+    if not text:
+        return None
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    fence = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
+    if fence:
+        try:
+            return json.loads(fence.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+
+    best = None
+    for span in _balanced_brace_spans(text):
+        try:
+            obj = json.loads(span)
+        except json.JSONDecodeError:
+            continue
+        if best is None or len(span) > best[0]:
+            best = (len(span), obj)
+    return best[1] if best else None
 
 
 def is_available(conf):
@@ -24,7 +95,10 @@ def run(prompt, system_prompt, conf, fallback):
     """Invoke Claude CLI and parse JSON response.
 
     Returns the parsed JSON dict on success, or a copy of `fallback` with
-    `recommendation` overwritten to describe the failure.
+    `recommendation` overwritten to describe the failure plus an explicit
+    sentinel key (`_cli_failed` or `_parse_failed`) so callers can detect
+    that the verifier never actually ran rather than inferring it from the
+    fallback verdict (which would otherwise look like a benign result).
     """
     claude_bin = conf.get("CLAUDE_BIN", "claude")
     model = conf.get("VERIFY_MODEL") or "sonnet"
@@ -51,18 +125,15 @@ def run(prompt, system_prompt, conf, fallback):
         result["recommendation"] = (
             f"Claude CLI failed (rc={proc.returncode}): {stderr[:500]}"
         )
+        result["_cli_failed"] = True
         return result
 
-    text = stdout.strip()
-    if text.startswith("```"):
-        lines = text.split("\n")
-        end = -1 if lines[-1].strip().startswith("```") else len(lines)
-        text = "\n".join(lines[1:end]).strip()
+    parsed = _extract_json(stdout)
+    if isinstance(parsed, dict):
+        return parsed
 
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        result["recommendation"] = (
-            f"Could not parse Claude response: {stdout[:500]}"
-        )
-        return result
+    result["recommendation"] = (
+        f"Could not parse Claude response: {stdout[:500]}"
+    )
+    result["_parse_failed"] = True
+    return result

--- a/dvd-ripper/tests/test_claude_parse.py
+++ b/dvd-ripper/tests/test_claude_parse.py
@@ -1,0 +1,68 @@
+"""Tests for claude._extract_json — robust JSON extraction from model output.
+
+The verify pipeline saw the model wrap its JSON verdict in a prose preamble
+("Now I have all the information needed. Let me compile the final JSON
+response. ...{json}"), which the old parser (leading-fence strip + json.loads)
+rejected, silently discarding all the structured verification work. These
+tests pin down the lenient extraction behavior that prevents that.
+"""
+
+import json
+import unittest
+
+import claude
+
+
+CLEAN = {"verdict": "pass", "confidence": 0.9, "issues": []}
+
+
+class ExtractJsonTest(unittest.TestCase):
+    def test_clean_json(self):
+        self.assertEqual(claude._extract_json(json.dumps(CLEAN)), CLEAN)
+
+    def test_fenced_json(self):
+        text = "```json\n" + json.dumps(CLEAN) + "\n```"
+        self.assertEqual(claude._extract_json(text), CLEAN)
+
+    def test_bare_fence(self):
+        text = "```\n" + json.dumps(CLEAN) + "\n```"
+        self.assertEqual(claude._extract_json(text), CLEAN)
+
+    def test_prose_preamble_then_json(self):
+        # The exact failure mode from the Brooklyn Nine-Nine rip.
+        text = (
+            "Now I have all the information needed. Let me compile the final "
+            "JSON response.\n\n" + json.dumps(CLEAN)
+        )
+        self.assertEqual(claude._extract_json(text), CLEAN)
+
+    def test_json_then_trailing_prose(self):
+        text = json.dumps(CLEAN) + "\n\nHope that helps!"
+        self.assertEqual(claude._extract_json(text), CLEAN)
+
+    def test_prose_with_small_brace_and_real_json(self):
+        # A stray brace in prose must not win over the real (larger) object.
+        text = (
+            "Consider the set {a, b}. Here is the verdict:\n"
+            + json.dumps(CLEAN)
+        )
+        self.assertEqual(claude._extract_json(text), CLEAN)
+
+    def test_nested_object_with_braces_in_strings(self):
+        obj = {
+            "verdict": "fail",
+            "recommendation": "use {curly} braces carefully",
+            "title_frame_check": {"attempted": True, "results": []},
+        }
+        text = "Here you go:\n" + json.dumps(obj) + "\nDone."
+        self.assertEqual(claude._extract_json(text), obj)
+
+    def test_unparseable_returns_none(self):
+        self.assertIsNone(claude._extract_json("no json here at all"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(claude._extract_json(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dvd-ripper/tests/test_verify.py
+++ b/dvd-ripper/tests/test_verify.py
@@ -300,6 +300,87 @@ class TestStageVerify(unittest.TestCase):
         self.assertIn("Re-rip", str(ctx.exception))
         self.assertEqual(ctx.exception.fix_command, fake_verdict["fix_command"])
 
+    def test_claude_parse_failure_raises(self):
+        """Unparseable Claude verdict must halt the pipeline, not soft-pass.
+
+        Reproduces the Brooklyn-99 bug: deterministic checks pass, but the
+        Claude CLI output couldn't be parsed, so claude.run returned the
+        fallback dict (verdict="warn") with recommendation prefixed
+        "Could not parse Claude response: ...". A "warn" verdict is normally
+        non-blocking, so the rip silently synced to Jellyfin without anyone
+        seeing that verification never actually ran. stage_verify must raise.
+        """
+        titles = [
+            {"id": i, "duration_secs": 1400, "segment_count": 1,
+             "segments": str(i), "name": "", "filename": ""}
+            for i in range(3)
+        ]
+        episodes = []
+        for t in titles:
+            mp4 = Path(self.tmpdir) / f"ep{t['id']}.mp4"
+            mp4.write_text("fake content")
+            episodes.append({
+                "title_id": t["id"],
+                "duration_secs": t["duration_secs"],
+                "mp4_path": str(mp4),
+            })
+        state = {
+            "titles": titles,
+            "media_type": "tv",
+            "plan": {"episodes": episodes},
+            "verification": {"issues": []},
+        }
+        conf = {"VERIFY_ENABLED": "true", "VERIFY_CLAUDE_ALWAYS": "true"}
+        # Mirror what claude.run returns on a parse failure: the fallback
+        # dict with only recommendation overwritten (+ sentinel flag).
+        parse_fail_verdict = {
+            "verdict": "warn", "confidence": 0.0, "issues": [],
+            "recommendation": "Could not parse Claude response: blah blah",
+            "fix_command": None,
+            "_parse_failed": True,
+        }
+        with patch("verify.claude.is_available", return_value=True), \
+             patch("verify.run_claude_verify", return_value=parse_fail_verdict):
+            with self.assertRaises(VerificationError) as ctx:
+                stage_verify(conf, state)
+        self.assertIn("could not", str(ctx.exception).lower())
+        self.assertIn("parse", str(ctx.exception).lower())
+
+    def test_claude_cli_failure_raises(self):
+        """CLI nonzero exit must halt the pipeline, not soft-pass."""
+        titles = [
+            {"id": i, "duration_secs": 1400, "segment_count": 1,
+             "segments": str(i), "name": "", "filename": ""}
+            for i in range(3)
+        ]
+        episodes = []
+        for t in titles:
+            mp4 = Path(self.tmpdir) / f"ep{t['id']}.mp4"
+            mp4.write_text("fake content")
+            episodes.append({
+                "title_id": t["id"],
+                "duration_secs": t["duration_secs"],
+                "mp4_path": str(mp4),
+            })
+        state = {
+            "titles": titles,
+            "media_type": "tv",
+            "plan": {"episodes": episodes},
+            "verification": {"issues": []},
+        }
+        conf = {"VERIFY_ENABLED": "true", "VERIFY_CLAUDE_ALWAYS": "true"}
+        cli_fail_verdict = {
+            "verdict": "warn", "confidence": 0.0, "issues": [],
+            "recommendation": "Claude CLI failed (rc=1): boom",
+            "fix_command": None,
+            "_cli_failed": True,
+        }
+        with patch("verify.claude.is_available", return_value=True), \
+             patch("verify.run_claude_verify", return_value=cli_fail_verdict):
+            with self.assertRaises(VerificationError) as ctx:
+                stage_verify(conf, state)
+        self.assertIn("could not", str(ctx.exception).lower())
+
     def test_count_mismatch_raises(self):
         """Episode count mismatch should raise VerificationError."""
         titles = [

--- a/dvd-ripper/verify.py
+++ b/dvd-ripper/verify.py
@@ -438,8 +438,21 @@ def stage_verify(conf, state):
         claude_result = run_claude_verify(prompt, conf)
         state["verification"]["claude_verdict"] = claude_result
 
-    # Claude's fail verdict halts the pipeline even without checker errors
+    # A Claude verdict we couldn't even read (CLI failed or unparseable
+    # output) must halt the pipeline and surface in the notification —
+    # otherwise the fallback verdict ("warn") silently looks like a soft
+    # pass and the rip syncs to Jellyfin with no verification.
     claude_verdict = state.get("verification", {}).get("claude_verdict")
+    if claude_verdict and (
+        claude_verdict.get("_parse_failed") or claude_verdict.get("_cli_failed")
+    ):
+        detail = (
+            "Claude verification could not be run: "
+            + claude_verdict.get("recommendation", "unknown error")
+        )
+        raise VerificationError(detail, recommendation=detail)
+
+    # Claude's fail verdict halts the pipeline even without checker errors
     if claude_verdict and claude_verdict.get("verdict") == "fail":
         recommendation = claude_verdict.get("recommendation", "")
         fix_command = claude_verdict.get("fix_command")


### PR DESCRIPTION
## Summary

Two related hardening changes to the dvd-ripper post-rip verification path. Both stem from a real Brooklyn-99 S6 rip where the Claude verifier's structured frame-check work was silently discarded.

### 1. Lenient JSON extraction (`claude.py`)
The verify model sometimes ignores the "JSON only" contract and wraps its verdict in a prose preamble (e.g. `"Now I have all the information...{json}"`), a trailing explanation, or a markdown fence. The old parser (leading-fence strip + `json.loads`) rejected these and silently dropped the whole verdict.

`_extract_json` now tries, in order:
1. The whole stripped text as JSON
2. The body of a ` ``` ` fenced block
3. The largest balanced `{...}` span that parses — via string-aware brace matching so braces inside JSON string values don't throw off the depth count

Covered by new `tests/test_claude_parse.py` (9 cases).

### 2. Fail loud when the verifier can't be read (`verify.py`, `claude.py`)
Previously, an unparseable verdict or a nonzero-exit CLI degraded to the fallback `verdict="warn"` — which is **non-blocking**. So a verification that *never actually ran* looked like a soft pass: the pipeline synced to Jellyfin with no notification that verification had failed.

Now `claude.run` marks its failure paths with `_cli_failed` / `_parse_failed` sentinels, and `stage_verify` raises `VerificationError` on them **before** the `"fail"` check — halting the pipeline and surfacing the failure in the notification.

Existing behavior preserved: a genuine `"fail"` still halts, a parseable `"warn"`/`"pass"` still proceeds, and deterministic checker errors still halt.

Covered by new tests in `tests/test_verify.py` (`test_claude_parse_failure_raises`, `test_claude_cli_failure_raises`).

## Testing
`python3 -m unittest discover tests` → **Ran 174 tests … OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)